### PR TITLE
feat: 認証APIの処理を追加

### DIFF
--- a/src/types/home.rs
+++ b/src/types/home.rs
@@ -1,3 +1,4 @@
+pub mod account;
 pub mod category;
 pub mod genre;
 pub mod me;

--- a/src/types/home.rs
+++ b/src/types/home.rs
@@ -1,2 +1,3 @@
 pub mod category;
+pub mod genre;
 pub mod me;

--- a/src/types/home.rs
+++ b/src/types/home.rs
@@ -1,1 +1,2 @@
+pub mod category;
 pub mod me;

--- a/src/types/home/account.rs
+++ b/src/types/home/account.rs
@@ -1,0 +1,23 @@
+/// Account
+///
+/// # Docs
+/// @see https://dev.zaim.net/home/api#account_home_get
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Account {
+    pub id: i32,
+    pub name: String,
+    // pub mode: String,
+    pub sort: i32,
+    pub parent_account_id: i32,
+    pub active: i32,
+    pub modified: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountResponse {
+    pub accounts: Vec<Account>,
+    pub requested: i32,
+}

--- a/src/types/home/category.rs
+++ b/src/types/home/category.rs
@@ -1,0 +1,23 @@
+/// Category
+///
+/// # Docs
+/// @see https://dev.zaim.net/home/api#category_home_get
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Category {
+    pub id: i32,
+    pub name: String,
+    pub mode: String,
+    pub sort: i32,
+    pub parent_category_id: i32,
+    pub active: i32,
+    pub modified: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CategoryResponse {
+    pub categories: Vec<Category>,
+    pub requested: i32,
+}

--- a/src/types/home/genre.rs
+++ b/src/types/home/genre.rs
@@ -1,0 +1,23 @@
+/// Genre
+///
+/// # Docs
+/// @see https://dev.zaim.net/home/api#genre_home_get
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Genre {
+    pub id: i32,
+    pub name: String,
+    pub sort: i32,
+    pub active: i32,
+    pub category_id: i32,
+    pub parent_genre_id: i32,
+    pub modified: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenreResponse {
+    pub genres: Vec<Genre>,
+    pub requested: i32,
+}

--- a/src/zaim/account.rs
+++ b/src/zaim/account.rs
@@ -1,8 +1,8 @@
 use reqwest::Method;
 
-use crate::types::default::account::DefaultAccountResponse;
+use crate::types::{default::account::DefaultAccountResponse, home::account::AccountResponse};
 
-use super::request::send_request_unauth;
+use super::request::{send_request, send_request_unauth};
 
 /// Fetch Default Accounts
 ///
@@ -30,6 +30,38 @@ pub async fn fetch_default_accounts() -> DefaultAccountResponse {
     let res = send_request_unauth(endpoint, Method::GET)
         .await
         .json::<DefaultAccountResponse>()
+        .await
+        .expect("failed to convert struct from json");
+
+    res
+}
+
+/// Fetch Accounts
+///
+/// Showing the list of your accounts.
+///
+/// # Docs
+/// @see https://dev.zaim.net/home/api#account_home_get
+///
+/// # Example
+/// Showing the list of your accounts.
+/// ```
+/// mod types;
+/// use zaim::zaim::account;
+///
+/// #[tokio::main]
+/// async fn main() {
+///   // Fetch Account
+///   let accounts = account::fetch_accounts().await.accounts;
+///   println!("{:?}", accounts);
+/// }
+/// ```
+pub async fn fetch_accounts() -> AccountResponse {
+    let endpoint = "account";
+
+    let res = send_request(endpoint, Method::GET)
+        .await
+        .json::<AccountResponse>()
         .await
         .expect("failed to convert struct from json");
 

--- a/src/zaim/category.rs
+++ b/src/zaim/category.rs
@@ -1,8 +1,8 @@
 use reqwest::Method;
 
-use crate::types::default::category::DefaultCategoryResponse;
+use crate::types::{default::category::DefaultCategoryResponse, home::category::CategoryResponse};
 
-use super::request::send_request_unauth;
+use super::request::{send_request, send_request_unauth};
 
 /// Fetch Default Categories
 ///
@@ -31,6 +31,39 @@ pub async fn fetch_default_categories() -> DefaultCategoryResponse {
     let res = send_request_unauth(endpoint, Method::GET)
         .await
         .json::<DefaultCategoryResponse>()
+        .await
+        .expect("failed to convert struct from json");
+
+    res
+}
+
+/// Fetch Categories
+///
+/// Showing the list of your categories.
+///
+/// # Docs
+/// @see https://dev.zaim.net/home/api#category_home_get
+///
+/// # Example
+/// Showing the list of your categories.
+/// ```
+/// use zaim::zaim::category;
+///
+/// mod types;
+///
+/// #[tokio::main]
+/// async fn main() {
+///   // Fetch Categories
+///   let categories = category::fetch_categories().await.categories;
+///   println!("{:?}", categories);
+/// }
+/// ```
+pub async fn fetch_categories() -> CategoryResponse {
+    let endpoint = "category";
+
+    let res = send_request(endpoint, Method::GET)
+        .await
+        .json::<CategoryResponse>()
         .await
         .expect("failed to convert struct from json");
 

--- a/src/zaim/genre.rs
+++ b/src/zaim/genre.rs
@@ -1,8 +1,8 @@
 use reqwest::Method;
 
-use crate::types::default::genre::DefaultGenreResponse;
+use crate::types::{default::genre::DefaultGenreResponse, home::genre::GenreResponse};
 
-use super::request::send_request_unauth;
+use super::request::{send_request, send_request_unauth};
 
 /// Fetch Default Genres
 ///
@@ -31,6 +31,39 @@ pub async fn fetch_default_genres() -> DefaultGenreResponse {
     let res = send_request_unauth(endpoint, Method::GET)
         .await
         .json::<DefaultGenreResponse>()
+        .await
+        .expect("failed to convert struct from json");
+
+    res
+}
+
+/// Fetch Genres
+///
+/// Showing the list of your genres.
+///
+/// # Docs
+/// @see https://dev.zaim.net/home/api#genre_home_get
+///
+/// # Example
+/// Showing the list of your genres.
+/// ```
+/// use zaim::zaim::genre;
+///
+/// mod types;
+///
+/// #[tokio::main]
+/// async fn main() {
+///   // Fetch Genres
+///   let genres = genre::fetch_genres().await.genres;
+///   println!("{:?}", genres);
+/// }
+/// ```
+pub async fn fetch_genres() -> GenreResponse {
+    let endpoint = "genre";
+
+    let res = send_request(endpoint, Method::GET)
+        .await
+        .json::<GenreResponse>()
         .await
         .expect("failed to convert struct from json");
 


### PR DESCRIPTION
## 対応内容
- 以下のAPIに対応
  - `Account List`
  - `Category List`
  - `Genre List`